### PR TITLE
fix build issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ template
 output
 fsh-generated
 .idea
+.vscode
 
 # Don't commit this because it's so large #
 ###########################################

--- a/FHIR-phd.xml
+++ b/FHIR-phd.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ciUrl="" defaultVersion="current" defaultWorkgroup="dev" gitUrl="https://github.com/HL7/PHD" url="http://hl7.org/fhir/uv/phd">
-<version code="current" url=""/>
+<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/uv/phd/2019May" ciUrl="http://build.fhir.org/ig/HL7/phd" defaultVersion="1.0.0" defaultWorkgroup="dev" gitUrl="https://github.com/HL7/PHD" url="http://hl7.org/fhir/uv/phd">
+<version code="current" url="http://build.fhir.org/ig/HL7/phd"/>
+<version code="1.0.0" url="http://hl7.org/fhir/uv/phd/STU1"/>
+<version code="0.3.0" url="http://hl7.org/fhir/uv/phd/2019May"/>
 <version code="0.2.0" deprecated="true" url="http://hl7.org/fhir/uv/phd/2019Jan"/>
+<version code="0.1.0" url="http://hl7.org/fhir/uv/phd/2018Jan"/>
 <version code="0.1" deprecated="true" url="http://hl7.org/fhir/uv/phd/2018Jan"/>
 <artifactPageExtension value="-definitions"/>
 <artifactPageExtension value="-examples"/>

--- a/ig.ini
+++ b/ig.ini
@@ -1,4 +1,4 @@
 [IG]
 ig = input/PhdImplementationGuide.xml
-template = hl7.fhir.template
+template = hl7.fhir.template#current
 usage-stats-opt-out = false

--- a/input-cache/schemas/R5/fhir-single.xsd
+++ b/input-cache/schemas/R5/fhir-single.xsd
@@ -47,7 +47,7 @@
   POSSIBILITY OF SUCH DAMAGE.
   
 
-  Generated on Mon, Apr 22, 2024 14:44+0000 for FHIR v6.0.0-cibuild 
+  Generated on Thu, Apr 25, 2024 12:40+0000 for FHIR v6.0.0-cibuild 
 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hl7.org/fhir" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:xml="http://www.w3.org/XML/1998/namespace" targetNamespace="http://hl7.org/fhir" elementFormDefault="qualified" version="6.0.0-cibuild">
   <!-- Note: When using this schema with some tools, it may also be necessary to declare xmlns:xml="http://www.w3.org/XML/1998/namespace", however this causes performance issues with other tools and thus is not in the base schemas. -->

--- a/input/pagecontent/ASN1BITsCodeSystem.md
+++ b/input/pagecontent/ASN1BITsCodeSystem.md
@@ -101,7 +101,7 @@ The mapped codes reported in the FHIR Observation.component.coding.code elements
 |150604.14|	device-equipment-malfunction|event|
 |150604.15|	device-extended-update|event|
 
-See [currently defined ASN1 Codes]({{ output }}ASN1ToHL7Codes.html) .
+See [currently defined ASN1 Codes]({{ output }}ASN1ToHL7Codes.html).
 
  - [Next: The Observation Identifier]({{ output }}ObservationIdentifier.html)
  - [Previous: Obtaining the Unit code]({{ output }}ObtainUnitCode.html)


### PR DESCRIPTION
An update of IG publisher caused errors when using Java script in HTML files.
Using the latest templates fixed the issue.